### PR TITLE
[고서영] Sprint 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,23 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>판다마켓</title>
         <link rel="icon" href="./styles/assets/icons/icon/panda.svg" />
+
+        <!-- Open Graph (OG) 메타 태그 -->
+        <meta property="og:title" content="판다마켓" />
+        <meta
+            property="og:description"
+            content="일상의 모든 물건을 거래해 보세요."
+        />
+        <meta
+            property="og:image"
+            content="https://www.google.com/imgres?q=%ED%8C%90%EB%8B%A4&imgurl=https%3A%2F%2Fi.namu.wiki%2Fi%2FN7XtnLu7mENPBU1wMlAoOo5_w13roksendvuswR8gkFw_8SilcxCpT3kTTdzaP42jSpZAQ2-R4x3aNxaj6A3JA.webp&imgrefurl=https%3A%2F%2Fnamu.wiki%2Fw%2F%25ED%258C%2590%25EB%258B%25A4&docid=5YXeSdnyXQW-OM&tbnid=L95TdOcl4sN4TM&vet=12ahUKEwiptZXLvcyMAxU7sVYBHUTEITMQM3oECG4QAA..i&w=578&h=385&hcb=2&ved=2ahUKEwiptZXLvcyMAxU7sVYBHUTEITMQM3oECG4QAA"
+        />
+        <meta
+            property="og:url"
+            content="https://namu.wiki/w/%ED%8C%90%EB%8B%A4/"
+        />
+        <meta property="og:type" content="website" />
+
         <!-- reset, normalize 파일 먼저 -->
         <link rel="stylesheet" href="./styles/reset.css" />
         <link rel="stylesheet" href="./styles/normalize.css" />

--- a/index.html
+++ b/index.html
@@ -1,113 +1,149 @@
 <!DOCTYPE html>
 <html lang="ko">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>판다마켓</title>
-    <link rel="icon" href="./styles/assets/icons/icon/panda.svg" />
-      <!-- reset, normalize 파일 먼저 -->
-    <link rel="stylesheet" href="./styles/reset.css" />
-    <link rel="stylesheet" href="./styles/normalize.css" />
-    <link rel="stylesheet" href="./styles/style.css" />
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>판다마켓</title>
+        <link rel="icon" href="./styles/assets/icons/icon/panda.svg" />
+        <!-- reset, normalize 파일 먼저 -->
+        <link rel="stylesheet" href="./styles/reset.css" />
+        <link rel="stylesheet" href="./styles/normalize.css" />
+        <link rel="stylesheet" href="./styles/style.css" />
 
-    <!-- components 폴더의 CSS들(순서는 사용 상황/우선순위에 맞게) -->
-    <link rel="stylesheet" href="./styles/components/Home.css" />
-    <link rel="stylesheet" href="./styles/components/buttons.css" />
-    <link rel="stylesheet" href="./styles/components/footer.css" />
-    <link rel="stylesheet" href="./styles/components/gnb.css" />
+        <!-- components 폴더의 CSS들(순서는 사용 상황/우선순위에 맞게) -->
+        <link rel="stylesheet" href="./styles/components/Home.css" />
+        <link rel="stylesheet" href="./styles/components/buttons.css" />
+        <link rel="stylesheet" href="./styles/components/footer.css" />
+        <link rel="stylesheet" href="./styles/components/gnb.css" />
 
-    <!-- 마지막으로 전체 스타일 -->
-    <link rel="stylesheet" href="./styles/style.css" />
-</head>
-<body>
-    <div>
-        <header class="gnb-wrapper">
-          <div class="gnb">
-            <a class="logo" href="/">
-                <img src="styles/assets/icons/icon/panda-sm.svg" alt="logo"/>
-            </a>
-            <a class="btn-small-48" href="/login.html">로그인</a>
-          </div>
-        </header>
-        
-        <main>
-            <section class="home-wrapper">
-                <div class="landing-text">
-                  <h2>일상의 모든 물건을 거래해 보세요</h2>
-                  <a class="btn-large" href="/items">구경하러가기</a>
+        <!-- 마지막으로 전체 스타일 -->
+        <link rel="stylesheet" href="./styles/style.css" />
+    </head>
+    <body>
+        <div>
+            <header class="gnb-wrapper">
+                <div class="gnb">
+                    <a class="logo" href="/">
+                        <img
+                            src="styles/assets/icons/icon/panda-sm.svg"
+                            alt="logo"
+                        />
+                    </a>
+                    <a class="btn-small-48" href="/login.html">로그인</a>
                 </div>
-                <img src="/styles/assets/images/Home/Img_home_top.svg" alt="home-top"/></div>
-            </section>
-            <section class="section-home-container">
-              <div class="section-home-wrapper">
-                <img src="/styles/assets/images/Home/Img_home_01.png" alt="section"/>
-                <div class="section-home-text">
-                  <span>Hot item</span>
-                  <h2>인기 상품을 <br />확인해 보세요</h2>
-                  <p>
-                    가장 HOT한 중고거래 물품을<br />
-                    판다 마켓에서 확인해 보세요
-                  </p>
-                </div>
-              </div>
-              <div class="section-home-wrapper reverse">
-                <img src="/styles/assets/images/Home/Img_home_02.png" alt="section"/>
-                <div class="section-home-text reverse">
-                  <span>Search</span>
-                  <h2>구매를 원하는 <br />
-                    상품을 검색하세요</h2>
-                  <p>
-                    구매하고 싶은 물품은 검색해서 <br />
-                    쉽게 찾아보세요
-                  </p>
-                </div>
-              </div>
-              <div class="section-home-wrapper">
-                <img src="/styles/assets/images/Home/Img_home_03.png" alt="section"/>
-                <div class="section-home-text">
-                  <span>Register</span>
-                  <h2>판매를 원하는 <br />상품을 등록하세요</h2>
-                  <p>
-                    어떤 물건이든 판매하고 싶은 상품을 <br />
-                    쉽게 등록하세요
-                  </p>
-                </div>
-              </div>
-            </section>
-            <section class="home-wrapper">
-              <div class="landing-text">
-                <h2>믿을 수 있는 <br/> 판다마켓 중고거래</h2>
-              </div>
-              <img src="/styles/assets/images/Home/Img_home_bottom.svg" alt="home-bottom"/>
-            </section>
+            </header>
 
-        </main>
-    
-        <footer>
-            <div class="footer-wrapper">
-              <span class="footer-info">
-                  @codeit-2025
-              </span>
-              <div class="footer-links">
-                <a href="/privacy">Privacy Policy</a>
-                <a href="/faq">FAQ</a>
-              </div>
-              <div class="sns-links">
-                  <a href="https://www.facebook.com" target="_blank">
-                    <img src="/styles/assets/icons/sns/ic_facebook.svg" alt="facebook" rel="noopener noreferrer"/>
-                  </a>
-                  <a href="https://twitter.com" target="_blank">
-                    <img src="/styles/assets/icons/sns/ic_twitter.svg" alt="twitter" rel="noopener noreferrer"/>
-                  </a>
-                  <a href="https://youtube.com" target="_blank">
-                    <img src="/styles/assets/icons/sns/ic_youtube.svg" alt="youtube" rel="noopener noreferrer"/>
-                  </a>
-                  <a href="https://instagram.com" target="_blank">
-                    <img src="/styles/assets/icons/sns/ic_instagram.svg" alt="instagram" rel="noopener noreferrer"/>
-                  </a>
-              </div>
+            <div class="home-container">
+                <section class="home-wrapper">
+                    <div class="landing-text top">
+                        <h2>일상의 모든 물건을 거래해 보세요</h2>
+                        <a class="btn-large" href="/items">구경하러가기</a>
+                    </div>
+                    <img
+                        src="/styles/assets/images/Home/Img_home_top.svg"
+                        alt="home-top"
+                    />
+                </section>
+                <section class="section-home-container">
+                    <div class="section-home-wrapper">
+                        <img
+                            src="/styles/assets/images/Home/Img_home_01.png"
+                            alt="home-card01"
+                        />
+                        <div class="section-home-text">
+                            <h1>Hot item</h1>
+                            <h2>인기 상품을 <br />확인해 보세요</h2>
+                            <p>
+                                가장 HOT한 중고거래 물품을<br />
+                                판다 마켓에서 확인해 보세요
+                            </p>
+                        </div>
+                    </div>
+                    <div class="section-home-wrapper reverse">
+                        <img
+                            src="/styles/assets/images/Home/Img_home_02.png"
+                            alt="home-card02"
+                        />
+                        <div class="section-home-text reverse">
+                            <h1>Search</h1>
+                            <h2>
+                                구매를 원하는 <br />
+                                상품을 검색하세요
+                            </h2>
+                            <p>
+                                구매하고 싶은 물품은 검색해서 <br />
+                                쉽게 찾아보세요
+                            </p>
+                        </div>
+                    </div>
+                    <div class="section-home-wrapper">
+                        <img
+                            src="/styles/assets/images/Home/Img_home_03.png"
+                            alt="home-card03"
+                        />
+                        <div class="section-home-text">
+                            <h1>Register</h1>
+                            <h2>판매를 원하는 <br />상품을 등록하세요</h2>
+                            <p>
+                                어떤 물건이든 판매하고 싶은 상품을 <br />
+                                쉽게 등록하세요
+                            </p>
+                        </div>
+                    </div>
+                </section>
+                <section class="home-wrapper">
+                    <div class="landing-text">
+                        <h2>
+                            믿을 수 있는 <br />
+                            판다마켓 중고거래
+                        </h2>
+                    </div>
+                    <img
+                        src="/styles/assets/images/Home/Img_home_bottom.svg"
+                        alt="home-bottom"
+                    />
+                </section>
             </div>
-        </footer>
-      </div>
-</body>
+
+            <footer>
+                <div class="footer-wrapper">
+                    <span class="footer-info"> @codeit-2025 </span>
+                    <div class="footer-links">
+                        <a href="/privacy">Privacy Policy</a>
+                        <a href="/faq">FAQ</a>
+                    </div>
+                    <div class="sns-links">
+                        <a href="https://www.facebook.com" target="_blank">
+                            <img
+                                src="/styles/assets/icons/sns/ic_facebook.svg"
+                                alt="facebook"
+                                rel="noopener noreferrer"
+                            />
+                        </a>
+                        <a href="https://twitter.com" target="_blank">
+                            <img
+                                src="/styles/assets/icons/sns/ic_twitter.svg"
+                                alt="twitter"
+                                rel="noopener noreferrer"
+                            />
+                        </a>
+                        <a href="https://youtube.com" target="_blank">
+                            <img
+                                src="/styles/assets/icons/sns/ic_youtube.svg"
+                                alt="youtube"
+                                rel="noopener noreferrer"
+                            />
+                        </a>
+                        <a href="https://instagram.com" target="_blank">
+                            <img
+                                src="/styles/assets/icons/sns/ic_instagram.svg"
+                                alt="instagram"
+                                rel="noopener noreferrer"
+                            />
+                        </a>
+                    </div>
+                </div>
+            </footer>
+        </div>
+    </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,55 +1,82 @@
 <!DOCTYPE html>
 <html lang="ko">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>판다마켓</title>
-    <link rel="icon" href="./styles/assets/icons/icon/panda.svg" />
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>판다마켓</title>
+        <link rel="icon" href="./styles/assets/icons/icon/panda.svg" />
 
-    <link rel="stylesheet" href="./styles/reset.css" />
-    <link rel="stylesheet" href="./styles/normalize.css" />
-    <link rel="stylesheet" href="./styles/style.css" />
-    <link rel="stylesheet" href="./styles/components/sign.css" />
-    <link rel="stylesheet" href="./styles/components/buttons.css" />
-    <link rel="stylesheet" href="./styles/components/footer.css" />
-</head>
-<body>
-    <div class="login-container">
-        <div class="login-logo">
-            <a class="logo" href="/">
-                <img src="styles/assets/icons/icon/panda-lg.svg" alt="logo"/>
-            </a>
-        </div>
-        <form method="post" class="login-form">
-            <div class="input-item">
-                <label for="email">이메일</label>
-                <input type="email" id="email" name="email" placeholder="이메일을 입력해 주세요" />
+        <link rel="stylesheet" href="./styles/reset.css" />
+        <link rel="stylesheet" href="./styles/normalize.css" />
+        <link rel="stylesheet" href="./styles/style.css" />
+        <link rel="stylesheet" href="./styles/components/sign.css" />
+        <link rel="stylesheet" href="./styles/components/buttons.css" />
+        <link rel="stylesheet" href="./styles/components/footer.css" />
+    </head>
+    <body>
+        <div class="login-container">
+            <div class="login-logo">
+                <a class="logo" href="/">
+                    <img
+                        src="styles/assets/icons/icon/panda-lg.svg"
+                        alt="logo"
+                    />
+                </a>
             </div>
-            <div class="input-item">
-                <label for="password">비밀번호</label>
-                <div class="input-wrapper">
-                    <input type="password" id="password" name="password" placeholder="비밀번호를 입력해 주세요" />
-                    <img src="styles/assets/icons/icon/eyes_off.svg" alt="toggle-password" class="toggle-password" />
+            <form method="post" class="login-form">
+                <div class="input-item">
+                    <label for="email">이메일</label>
+                    <input
+                        type="email"
+                        id="email"
+                        name="email"
+                        placeholder="이메일을 입력해 주세요"
+                    />
+                </div>
+                <div class="input-item">
+                    <label for="password">비밀번호</label>
+                    <div class="input-wrapper">
+                        <input
+                            type="password"
+                            id="password"
+                            name="password"
+                            placeholder="비밀번호를 입력해 주세요"
+                        />
+                        <button>
+                            <img
+                                src="styles/assets/icons/icon/eyes_off.svg"
+                                alt="toggle-password"
+                                class="toggle-password"
+                            />
+                        </button>
+                    </div>
+                </div>
+                <button type="submit" class="btn-large full-width">
+                    로그인
+                </button>
+            </form>
+            <div class="social-login-container">
+                <h3>간편 로그인하기</h3>
+                <div class="social-login-wrapper">
+                    <a href="https://www.google.com" target="_blank">
+                        <img
+                            src="styles/assets/icons/sns/Google.svg"
+                            alt="google-login"
+                        />
+                    </a>
+                    <a href="https://www.kakaocrop.com/page/" target="_blank">
+                        <img
+                            src="styles/assets/icons/sns/Kakao.svg"
+                            alt="kakao-login"
+                        />
+                    </a>
                 </div>
             </div>
-            <button type="submit" class="btn-large full-width">로그인</button>
-        </form>
-        <div class="social-login-container">
-            <h3>간편 로그인하기</h3>
-            <div class="social-login-wrapper">
-                <a href="https://www.google.com" target="_blank">
-                    <img src="styles/assets/icons/sns/Google.svg" alt="google-login"/>
-                </a>
-                <a href="https://www.kakaocrop.com/page/" target="_blank">
-                    <img src="styles/assets/icons/sns/Kakao.svg" alt="kakao-login"/>
-                </a>
+            <div class="login-footer">
+                <p>
+                    판다마켓이 처음이신가요? <a href="/signup.html">회원가입</a>
+                </p>
             </div>
         </div>
-        <div class="login-footer">
-            <p>
-                판다마켓이 처음이신가요? <a href="/signup.html">회원가입</a> 
-            </p> 
-        </div>
-    </div>
-</body>
+    </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -1,66 +1,107 @@
 <!DOCTYPE html>
 <html lang="ko">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>판다마켓</title>
-    <link rel="icon" href="./styles/assets/icons/icon/panda.svg" />
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>판다마켓</title>
+        <link rel="icon" href="./styles/assets/icons/icon/panda.svg" />
 
-    <link rel="stylesheet" href="./styles/reset.css" />
-    <link rel="stylesheet" href="./styles/normalize.css" />
-    <link rel="stylesheet" href="./styles/style.css" />
-    <link rel="stylesheet" href="./styles/components/sign.css" />
-    <link rel="stylesheet" href="./styles/components/buttons.css" />
-    <link rel="stylesheet" href="./styles/components/footer.css" />
-</head>
-<body>
-    <div class="login-container">
-        <div class="login-logo">
-            <a class="logo" href="/">
-                <img src="styles/assets/icons/icon/panda-lg.svg" alt="logo"/>
-            </a>
-        </div>
-        <form method="post" class="login-form">
-            <div class="input-item">
-                <label for="email">이메일</label>
-                <input type="email" id="email" name="email" placeholder="이메일을 입력해 주세요" />
-            </div>
-            <div class="input-item">
-                <label for="username">닉네임</label>
-                <input type="username" id="username" name="username" placeholder="닉네임을 입력해 주세요" />
-            </div>
-            <div class="input-item">
-                <label for="password">비밀번호</label>
-                <div class="input-wrapper">
-                    <input type="password" id="password" name="password" placeholder="비밀번호를 입력해 주세요" />
-                    <img src="styles/assets/icons/icon/eyes_off.svg" alt="toggle-password" class="toggle-password" />
-                </div>
-            </div>
-            <div class="input-item">
-                <label for="password">비밀번호 확인</label>
-                <div class="input-wrapper">
-                    <input type="password" id="password" name="password" placeholder="비밀번호를 다시 한 번 입력해 주세요" />
-                    <img src="styles/assets/icons/icon/eyes_off.svg" alt="toggle-password" class="toggle-password" />
-                </div>
-            </div>
-            <button type="submit" class="btn-large full-width">회원가입</button>
-        </form>
-        <div class="social-login-container">
-            <h3>간편 로그인하기</h3>
-            <div class="social-login-wrapper">
-                <a href="https://www.google.com" target="_blank">
-                    <img src="styles/assets/icons/sns/Google.svg" alt="google-login"/>
-                </a>
-                <a href="https://www.kakaocrop.com/page/" target="_blank">
-                    <img src="styles/assets/icons/sns/Kakao.svg" alt="kakao-login"/>
+        <link rel="stylesheet" href="./styles/reset.css" />
+        <link rel="stylesheet" href="./styles/normalize.css" />
+        <link rel="stylesheet" href="./styles/style.css" />
+        <link rel="stylesheet" href="./styles/components/sign.css" />
+        <link rel="stylesheet" href="./styles/components/buttons.css" />
+        <link rel="stylesheet" href="./styles/components/footer.css" />
+    </head>
+    <body>
+        <div class="login-container">
+            <div class="login-logo">
+                <a class="logo" href="/">
+                    <img
+                        src="styles/assets/icons/icon/panda-lg.svg"
+                        alt="logo"
+                    />
                 </a>
             </div>
+            <form method="post" class="login-form">
+                <div class="input-item">
+                    <label for="email">이메일</label>
+                    <input
+                        type="email"
+                        id="email"
+                        name="email"
+                        placeholder="이메일을 입력해 주세요"
+                    />
+                </div>
+                <div class="input-item">
+                    <label for="username">닉네임</label>
+                    <input
+                        type="username"
+                        id="username"
+                        name="username"
+                        placeholder="닉네임을 입력해 주세요"
+                    />
+                </div>
+                <div class="input-item">
+                    <label for="password">비밀번호</label>
+                    <div class="input-wrapper">
+                        <input
+                            type="password"
+                            id="password"
+                            name="password"
+                            placeholder="비밀번호를 입력해 주세요"
+                        />
+                        <button>
+                            <img
+                                src="styles/assets/icons/icon/eyes_off.svg"
+                                alt="toggle-password"
+                                class="toggle-password"
+                            />
+                        </button>
+                    </div>
+                </div>
+                <div class="input-item">
+                    <label for="password">비밀번호 확인</label>
+                    <div class="input-wrapper">
+                        <input
+                            type="password"
+                            id="password"
+                            name="password"
+                            placeholder="비밀번호를 다시 한 번 입력해 주세요"
+                        />
+                        <button>
+                            <img
+                                src="styles/assets/icons/icon/eyes_off.svg"
+                                alt="toggle-password"
+                                class="toggle-password"
+                            />
+                        </button>
+                    </div>
+                </div>
+                <button type="submit" class="btn-large full-width">
+                    회원가입
+                </button>
+            </form>
+            <div class="social-login-container">
+                <h3>간편 로그인하기</h3>
+                <div class="social-login-wrapper">
+                    <a href="https://www.google.com" target="_blank">
+                        <img
+                            src="styles/assets/icons/sns/Google.svg"
+                            alt="google-login"
+                        />
+                    </a>
+                    <a href="https://www.kakaocrop.com/page/" target="_blank">
+                        <img
+                            src="styles/assets/icons/sns/Kakao.svg"
+                            alt="kakao-login"
+                        />
+                    </a>
+                </div>
+            </div>
+            <div class="login-footer">
+                <p>이미 회원이신가요? <a href="/login.html">로그인</a></p>
+            </div>
         </div>
-        <div class="login-footer">
-            <p>
-                이미 회원이신가요? <a href="/login.html">로그인</a> 
-            </p> 
-        </div>
-    </div>
-</body>
+    </body>
 </html>

--- a/styles/components/Home.css
+++ b/styles/components/Home.css
@@ -1,23 +1,23 @@
-main{
+.home-container {
     display: flex;
     flex-direction: column;
 }
 /* landing top,bottom */
-.home-wrapper{
+.home-wrapper {
     display: flex;
     flex-direction: row;
     justify-content: center;
-    align-items:flex-end;
+    align-items: flex-end;
 
     height: 540px;
-    background-color: #CFE5FF;
+    background-color: #cfe5ff;
 }
 
-.home-wrapper h2{
+.home-wrapper h2 {
     font: var(--text-3xl-bold);
     color: var(--gray---700);
 }
-.landing-text{
+.landing-text {
     display: flex;
     flex-direction: column;
     width: 357px;
@@ -31,14 +31,16 @@ main{
 }
 
 /* section 설명 부분 */
-.section-home-container{
+.section-home-container {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
+
+    background-color: #fcfcfc;
 }
 
-.section-home-wrapper{
+.section-home-wrapper {
     display: flex;
     flex-direction: row;
     justify-content: center;
@@ -50,21 +52,22 @@ main{
     padding: 0 10px;
     gap: 64px;
 
-    background-color: #FCFCFC;
+    background-color: #fcfcfc;
 }
-.section-home-wrapper.reverse{
+.section-home-wrapper.reverse {
     flex-direction: row-reverse;
 }
-.section-home-text{
+
+/* home section 글자 부분 */
+.section-home-text {
     display: flex;
     flex-direction: column;
     margin: 103px 0;
     gap: 12px;
 }
-.section-home-text span{
+.section-home-text {
     font: var(--text-2lg-bold);
     color: var(--primary---100);
-    
 }
 
 .section-home-text h2 {
@@ -78,4 +81,71 @@ main{
 
 .section-home-text.reverse {
     text-align: right;
+}
+
+@media (max-width: 1200px) {
+    .home-wrapper {
+        flex-direction: column;
+        align-items: center;
+        height: auto;
+        padding-top: 80px;
+    }
+    .home-wrapper img {
+        width: 100%;
+        height: auto;
+    }
+    .landing-text {
+        align-items: center;
+        transition: 0.5s;
+    }
+    .landing-text h2 {
+        text-align: center;
+    }
+    .landing-text.top {
+        width: auto;
+    }
+    .landing-text.top h2 {
+        width: 100%;
+    }
+    /* section */
+    .section-home-container {
+        width: 100%;
+        padding: 0 24px;
+    }
+    .section-home-wrapper {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0;
+
+        width: 100%;
+        height: auto;
+        /* height의 중요성!! */
+        padding: 0;
+        margin: 26px 0;
+    }
+    .section-home-wrapper.reverse {
+        flex-direction: column;
+    }
+    .section-home-wrapper img {
+        width: 100%;
+    }
+    .section-home-text {
+        margin: 24px 0;
+    }
+    .section-home-text h2 br {
+        display: none;
+    }
+}
+
+@media (max-width: 768px) {
+    .landing-text.top {
+        width: 240px;
+        transition: 0.5s;
+    }
+    .section-home-container {
+        padding: 32px 16px;
+    }
+    .section-home-wrapper {
+        margin: 20px 0;
+    }
 }

--- a/styles/components/buttons.css
+++ b/styles/components/buttons.css
@@ -61,3 +61,12 @@ button {
 .full-width {
     width: 100%;
 }
+
+@media (max-width: 768px) {
+    .btn-large {
+        width: 100%;
+        padding: 16px 71px;
+        font: var(--text-2lg-semibold);
+        transition: 0.5s;
+    }
+}

--- a/styles/components/footer.css
+++ b/styles/components/footer.css
@@ -1,4 +1,4 @@
-footer{
+footer {
     height: 160px;
     font-weight: 400;
     background-color: var(--gray---900);
@@ -7,7 +7,7 @@ footer{
     align-items: flex-start;
 }
 
-.footer-wrapper{
+.footer-wrapper {
     display: flex;
     justify-content: space-evenly;
     align-items: center;
@@ -15,18 +15,36 @@ footer{
     padding-top: 32px;
 }
 
-.footer-info{
+.footer-info {
     color: var(--gray---400);
 }
-.footer-links{
+.footer-links {
     display: flex;
     gap: 30px;
 }
-.footer-links a{
+.footer-links a {
     color: var(--gray---200);
 }
-.sns-links{
+.sns-links {
     display: flex;
     gap: 12px;
 }
 
+@media (max-width: 768px) {
+    .footer-wrapper {
+        position: relative;
+        padding: 32px 32px 0 32px;
+    }
+
+    .footer-info {
+        position: absolute;
+        top: 111px;
+        left: 32px;
+    }
+
+    .footer-links {
+        justify-content: space-between;
+        width: 50%;
+        margin-right: auto;
+    }
+}

--- a/styles/components/gnb.css
+++ b/styles/components/gnb.css
@@ -25,6 +25,18 @@
         padding: 9px 0;
     }
     .gnb{
-        margin: 0 200px;
+        margin: 0 100px;
+    }
+}
+
+@media (max-width: 1200px) {
+    .gnb{
+        margin: 0 24px;
+    }
+}
+
+@media (max-width: 768px) {
+    .gnb{
+        margin: 0 16px;
     }
 }

--- a/styles/components/sign.css
+++ b/styles/components/sign.css
@@ -1,19 +1,19 @@
-.login-container{
+.login-container {
     display: flex;
     flex-direction: column;
-    /* justify-content: center; */
+    justify-content: center;
     align-items: center;
     width: 100%;
     max-width: 640px;
     height: 100vh;
     gap: 40px;
-    margin: 60px auto;
+    margin: 80px auto;
 }
-.login-logo{
+.login-logo {
     display: flex;
     align-items: center;
 }
-.login-logo .logo span{
+.login-logo .logo span {
     color: var(--primary---100);
     font-weight: 700;
     font-size: 66.34px;
@@ -25,17 +25,14 @@
     width: 103.53;
 }
 
-.login-container {
-    display: flex;
-    flex-direction: column;
-}
-
 .login-form {
     display: flex;
     flex-direction: column;
     gap: 24px;
     width: 640px;
 }
+
+/* -------------input---------------- */
 .input-item {
     display: flex;
     flex-direction: column;
@@ -74,10 +71,11 @@
     position: absolute;
     right: 24px;
     top: 50%;
-    transform: translateY(-50%);
+    transform: translateY(-80%);
     cursor: pointer;
 }
 
+/* -----------------social login--------------------- */
 .social-login-container {
     display: flex;
     justify-content: space-between;
@@ -86,7 +84,7 @@
     width: 640px;
     height: 74px;
     padding: 16px 23px;
-    background-color: #E6F2FF;
+    background-color: #e6f2ff;
     border-radius: 8px;
 }
 
@@ -103,7 +101,28 @@
     color: var(--gray---800);
 }
 
-.login-footer a{
+.login-footer a {
     color: var(--primary---100);
     text-decoration: underline;
+}
+@media (max-width: 768px) {
+    .login-container {
+        justify-content: center;
+        align-items: center;
+        margin: 0 auto;
+        padding: 0 16px;
+        max-width: 400px;
+        gap: 24px;
+    }
+    .login-logo .logo img {
+        width: 198px;
+        transition: 0.5s;
+    }
+    .login-form {
+        width: 100%;
+        gap: 16px;
+    }
+    .social-login-container {
+        width: 100%;
+    }
 }


### PR DESCRIPTION
## 요구사항

### 기본

**공통**

- [x]  브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
    - [x]  PC: `1200px` 이상
    - [x]  Tablet: `768px` 이상 ~ `1199px` 이하
    - [x]  Mobile: `375px` 이상 ~ `767px` 이하
    - [x]  `375px` 미만 사이즈의 디자인은 고려하지 않습니다

**랜딩 페이지**

- [x]  Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 `24px`, “로그인” 버튼 오른쪽 여백 `24px`을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x]  Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 `16px`, “로그인” 버튼 오른쪽 여백 `16px`을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x]  화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

**로그인, 회원가입 페이지 공통**

- [x]  Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x]  Mobile 사이즈에서 좌우 여백 `16px` 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x]  Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 `400px`을 넘지 않습니다.

### 심화

- [x]  페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [x]  미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [x]  주소와 이미지는 자유롭게 설정하세요.

## 주요 변경사항

- h 계층 구조 완벽 이해!
- button 설정을 하니까 img 위치가 변하길래 css 수정도 했습니다.
- css가 많아지다보니 좀 더 잘 구분되도록 주석 추가했습니다.

## 스크린샷

<img width="400" alt="스크린샷 2025-04-10 오후 12 13 44" src="https://github.com/user-attachments/assets/899a2fd0-3664-481a-b561-ede676d9f5b3" />
<img width="400" alt="스크린샷 2025-04-10 오후 12 14 05" src="https://github.com/user-attachments/assets/b6b58e0a-81b4-4256-b30e-1b1aa60f7a18" />
<img width="406" alt="스크린샷 2025-04-10 오후 12 14 24" src="https://github.com/user-attachments/assets/03223223-8015-4569-8342-1b0024fa8afa" />
<img width="405" alt="스크린샷 2025-04-10 오후 12 15 10" src="https://github.com/user-attachments/assets/6423eb6f-0165-4123-8cb0-71b81e0d8516" />


## 멘토에게

- footer css 부분에 대한 자세한 피드백 부탁드립니다.
- 
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
